### PR TITLE
Fixing linker error

### DIFF
--- a/include/connect_user.h
+++ b/include/connect_user.h
@@ -24,8 +24,8 @@
 #define MAXDATASIZE 100
 #define MAXLINE 4096
 
-Node *user_list;
-pthread_mutex_t user_list_mutex;
+extern Node *user_list;
+extern pthread_mutex_t user_list_mutex;
 
 void connect_user(User *);
 

--- a/modules/connect_user.c
+++ b/modules/connect_user.c
@@ -1,5 +1,8 @@
 #include "../include/connect_user.h"
 
+Node *user_list;
+pthread_mutex_t user_list_mutex;
+
 void connect_user(User *user) {
     printf("[Usuario %d conectou-se ao servidor, esperando mensagens]\n", user->id);
     char recvline[MAXLINE + 1];


### PR DESCRIPTION
There was an error while compiling because two variables in the header file were not declared as extern.